### PR TITLE
fix bugs with clang compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,12 @@ SRC_DIR := ./bubbleSim
 SRCS := $(SRC_DIR)/bubble.cpp $(SRC_DIR)/openclwrapper.cpp $(SRC_DIR)/simulation.cpp $(SRC_DIR)/source.cpp $(SRC_DIR)/datastreamer.cpp
 OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)
 
+#CXX=clang
 CXX=g++
 
 #link against common OCL headers
-CXXFLAGS=-fpermissive -std=c++2a -I./dependencies/json/
-LDFLAGS=-L/usr/lib/x86_64-linux-gnu/ -lOpenCL
+CXXFLAGS=-std=c++2a -I./dependencies/json/
+LDFLAGS=-L/usr/lib/x86_64-linux-gnu/ -lOpenCL -lm -lstdc++
 
 # The final build step of the executable
 $(BUILD_DIR)/$(TARGET_EXEC): $(OBJS)

--- a/bubbleSim/openclwrapper.cpp
+++ b/bubbleSim/openclwrapper.cpp
@@ -162,7 +162,7 @@ void OpenCLWrapper::createContext(std::vector<cl::Device>& devices) {
         exit(1);
     }
 
-    m_context = cl::Context::Context(devices, NULL, NULL, NULL, &errNum);
+    m_context = cl::Context(devices, NULL, NULL, NULL, &errNum);
     m_deviceUsed = devices[0];
 
     if (errNum != CL_SUCCESS) {
@@ -177,7 +177,7 @@ void OpenCLWrapper::createProgram(cl::Context& context, cl::Device& device, std:
     std::ifstream kernel_file(kernelFile);
     std::string kernel_code(std::istreambuf_iterator<char>(kernel_file), (std::istreambuf_iterator<char>()));
 
-    m_program = cl::Program::Program(context, kernel_code, false, &errNum);
+    m_program = cl::Program(context, kernel_code, false, &errNum);
     if (errNum != CL_SUCCESS) {
         std::cerr << "Failed to create program from source file. Cehck if kernel file location is correct. (" << kernelFile << ")" << std::endl;
         exit(1);
@@ -193,7 +193,7 @@ void OpenCLWrapper::createProgram(cl::Context& context, cl::Device& device, std:
 
 void OpenCLWrapper::createKernel(cl::Program& program, const char* name) {
     int errNum;
-    m_kernel = cl::Kernel::Kernel(program, name, &errNum);
+    m_kernel = cl::Kernel(program, name, &errNum);
     if (errNum != CL_SUCCESS) {
         std::cerr << "Failed to create a kernel: " << name << std::endl;
         exit(1);


### PR DESCRIPTION
When compiling with clang instead of gcc, we have this error:
```
bubbleSim/openclwrapper.cpp:165:30: error: qualified reference to 'Context' is a constructor name rather than a type in this context
    m_context = cl::Context::Context(devices, NULL, NULL, NULL, &errNum);
                             ^
bubbleSim/openclwrapper.cpp:180:30: error: qualified reference to 'Program' is a constructor name rather than a type in this context
    m_program = cl::Program::Program(context, kernel_code, false, &errNum);
                             ^
bubbleSim/openclwrapper.cpp:196:28: error: qualified reference to 'Kernel' is a constructor name rather than a type in this context
    m_kernel = cl::Kernel::Kernel(program, name, &errNum);
```

It's not correct to call constructors like this. This PR fixes it.