### PR TITLE
added script to run multiple simulations in parallel on the GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ singularity exec --env POCL_DEVICES=basic $IMG build/bubbleSim.exe bubbleSim/con
 #Run on GPU (only on a GPU machine)
 singularity exec --nv --env LD_LIBRARY_PATH=/usr/local/cuda/lib64 $IMG build/bubbleSim.exe bubbleSim/config.json
 ```
+
+Submit to GPU queue:
+```
+#Run one simulation per GPU
+sbatch scripts/bubblesim-gpu.sh
+
+#Run 4 simulations in parallel on one GPU
+sbatch scripts/bubblesim-gpu-p4.sh config1.json config2.json config3.json config4.json
+```

--- a/scripts/bubblesim-gpu-p4.sh
+++ b/scripts/bubblesim-gpu-p4.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#SBATCH -p gpu
+#SBATCH --gpus 1
+#SBATCH --mem-per-gpu=2G
+#SBATCH -o logs/slurm-%x-%j-%N.out
+
+WORKDIR=/scratch/$USER/${SLURM_JOB_ID}
+IMG=/home/software/singularity/base
+BUBBLESIM_DIR=~/bubbleSim
+
+#create a local dir on the worker node
+mkdir -p $WORKDIR
+cd $WORKDIR
+
+#copy the kernel file to the local dir
+cp $BUBBLESIM_DIR/bubbleSim/kernel.cl ./
+cp $BUBBLESIM_DIR/build/bubbleSim.exe ./
+ls -lrt .
+
+singularity exec --nv \
+	--env LD_LIBRARY_PATH=/usr/local/cuda/lib64 \
+	--env CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES \
+        -B $WORKDIR -B $BUBBLESIM_DIR \
+	$IMG \
+	./bubbleSim.exe $BUBBLESIM_DIR/bubbleSim/$1 &> log_1.txt &
+
+singularity exec --nv \
+	--env LD_LIBRARY_PATH=/usr/local/cuda/lib64 \
+	--env CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES \
+        -B $WORKDIR -B $BUBBLESIM_DIR \
+	$IMG \
+	./bubbleSim.exe $BUBBLESIM_DIR/bubbleSim/$2 &> log_2.txt &
+
+singularity exec --nv \
+	--env LD_LIBRARY_PATH=/usr/local/cuda/lib64 \
+	--env CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES \
+        -B $WORKDIR -B $BUBBLESIM_DIR \
+	$IMG \
+	./bubbleSim.exe $BUBBLESIM_DIR/bubbleSim/$3 &> log_3.txt &
+
+singularity exec --nv \
+	--env LD_LIBRARY_PATH=/usr/local/cuda/lib64 \
+	--env CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES \
+        -B $WORKDIR -B $BUBBLESIM_DIR \
+	$IMG \
+	./bubbleSim.exe $BUBBLESIM_DIR/bubbleSim/$4 &> log_4.txt &
+
+#wait for parallel jobs to finish
+wait
+
+#print logs
+cat log_*.txt
+
+#remove temp dir
+rm -Rf $WORKDIR


### PR DESCRIPTION
When running on the GPUs in the cluster using `sbatch`, it's possible to run e.g. 4 simulations in parallel on the same GPU with essentially linear speedup.

Here's an example script for this, along with some instructions.