### PR TITLE
fix opencl readwrite bug

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,11 @@ jobs:
           sudo apt install -y gcc g++
           sudo apt install -y opencl-c-headers opencl-clhpp-headers ocl-icd-opencl-dev
           sudo apt install -y pocl-opencl-icd
+          sudo apt install -y oclgrind
       - name: build
         run: make
       - name: run
         run: |
           mkdir data
           POCL_DEVICES=basic ./build/bubbleSim.exe bubbleSim/config.json
+          oclgrind ./build/bubbleSim.exe bubbleSim/config.json


### PR DESCRIPTION
I ran https://github.com/jrprice/Oclgrind on the code, which checks for runtime errors in the kernel.
It was detecting the following stuff:

```
Invalid write to read-only buffer
	Kernel: step_double
	Entity: Global(268,0,0) Local(0,0,0) Group(268,0,0)
	  store i8 %conv75, i8 addrspace(1)* %arrayidx72, align 1, !dbg !172
	At line 151 (column 21) of input.cl:
	  passedFalse[gid] += 0;
	

Invalid write to read-only buffer
	Kernel: step_double
	Entity: Global(274,0,0) Local(0,0,0) Group(274,0,0)
	  store i8 %conv70, i8 addrspace(1)* %arrayidx67, align 1, !dbg !169
	At line 150 (column 25) of input.cl:
	  interactedFalse[gid] += 0;
	

Invalid write to read-only buffer
	Kernel: step_double
	Entity: Global(263,0,0) Local(0,0,0) Group(263,0,0)
	  store i8 %conv80, i8 addrspace(1)* %arrayidx77, align 1, !dbg !175
	At line 152 (column 24) of input.cl:
	  interactedTrue[gid] += 0;
```

This PR fixes it.

There was also a mistaken way of getting the OCL device in an unusual place, which I fixed.