### PR TITLE
fail CI in case of errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,32 +15,76 @@ jobs:
       - uses: actions/checkout@v3
       - name: install deps
         run: |
-          sudo apt install -y gcc g++
+          sudo apt install -y gcc g++ clang
           sudo apt install -y opencl-c-headers opencl-clhpp-headers ocl-icd-opencl-dev
           sudo apt install -y pocl-opencl-icd
           sudo apt install -y oclgrind
+
       - name: build
         run: make
+
       - name: run
         run: |
           mkdir data
           POCL_DEVICES=pthread ./build/bubbleSim.exe bubbleSim/config.json &> log_pthread.txt
-          head -n10 log_pthread.txt
-          tail -n10 log_pthread.txt
-
           POCL_DEVICES=basic ./build/bubbleSim.exe bubbleSim/config.json &> log_basic.txt
-          head -n10 log_basic.txt
-          tail -n10 log_basic.txt
+
+          diff log_basic.txt log_pthread.txt > diff1.txt || true
+          export NUMDIFF=$(wc -l < diff1.txt)
+          echo "diff lines "$NUMDIFF
+
+          #fail if there are more than 10 lines of difference between the two logs
+          if [[ $NUMDIFF -ge 10 ]] ; then
+            echo "too many differences, failing"
+            exit 1
+          fi
+      
+      - name: build with O3
+        run: |
+          make clean
+          OPTFLAGS=-O3 make -j4
+          POCL_DEVICES=pthread ./build/bubbleSim.exe bubbleSim/config.json &> log_pthread_O3.txt
+
+          diff log_pthread.txt log_pthread_O3.txt > diff2.txt || true
+          export NUMDIFF=$(wc -l < diff2.txt)
+          echo "diff lines "$NUMDIFF
+
+          #fail if there are more than 10 lines of difference between the two logs
+          if [[ $NUMDIFF -ge 10 ]] ; then
+            echo "too many differences, failing"
+            exit 1
+          fi
+
+      - name: build with clang
+        run: |
+          make clean
+          CXX=clang make -j4
+          POCL_DEVICES=pthread ./build/bubbleSim.exe bubbleSim/config.json &> log_pthread_clang.txt
+
+          diff log_pthread.txt log_pthread_clang.txt > diff3.txt || true
+          export NUMDIFF=$(wc -l < diff3.txt)
+          echo "diff lines "$NUMDIFF
+
+          #fail if there are more than 10 lines of difference between the two logs
+          if [[ $NUMDIFF -ge 10 ]] ; then
+            echo "too many differences, failing"
+            exit 1
+          fi
+
       - name: oclgrind
         run: |
-          oclgrind ./build/bubbleSim.exe bubbleSim/config.json &> log_oclgrind.txt
-          head -n10 log_basic.txt
-          tail -n10 log_basic.txt
+          oclgrind --log oclgrind.log ./build/bubbleSim.exe bubbleSim/config.json &> log_oclgrind.txt
+          tail -n10 oclgrind.log
+
+          #fail if oclgrind.log is not empty
+          if [[ -s oclgrind.log ]] ; then
+            echo "oclgrind log is not empty"
+            exit 1
+          fi
+
       - name: asan
         run: |
           make clean
           OPTFLAGS="-O0 -fsanitize=address -g" make
           ASAN_OPTIONS="verbose=1,abort_on_error=1" ./build/bubbleSim.exe bubbleSim/config.json &> log_asan.txt
-          head -n10 log_asan.txt
-          tail -n10 log_asan.txt
-           
+


### PR DESCRIPTION
Make sure the CI test fails in case any of the following are true:
- if the log differences between single-threaded, multi-threaded, gcc/clang, or "-O3" are greater than 10 lines
- if the `oclgrind` log is not empty
- if ASAN detects memory issues.