### PR TITLE
Energy distribution profiling (radial)

### DIFF
--- a/bubbleSim/datastreamer.h
+++ b/bubbleSim/datastreamer.h
@@ -15,6 +15,7 @@ class DataStreamer {
 
   void initMomentumProfile(size_t t_binsCount, numType t_maxMomentumValue);
   void initDensityProfile(size_t t_binsCount, numType t_maxRadiusValue);
+  void initEnergyDensityProfile(size_t t_binsCount, numType t_maxRadiusValue);
   void initData();
   void stream(Simulation& simulation, ParticleCollection& particleCollection,
               PhaseBubble& bubble, cl::CommandQueue& cl_queue);
@@ -25,6 +26,7 @@ class DataStreamer {
   std::fstream m_fileMomentumIn;
   std::fstream m_fileMomentumOut;
   std::fstream m_fileDensity;
+  std::fstream m_fileEnergyDensity;
   std::fstream m_fileData;
 
   bool m_momentumInitialized = false;

--- a/bubbleSim/source.cpp
+++ b/bubbleSim/source.cpp
@@ -253,6 +253,9 @@ int main(int argc, char* argv[]) {
   if (config.streamDensityOn) {
     streamer.initDensityProfile(config.streamDensityBinsCount,
                                 config.bubbleInitialRadius * 2 * std::sqrt(3));
+    streamer.initEnergyDensityProfile(
+        config.streamDensityBinsCount,
+        config.bubbleInitialRadius * 2 * std::sqrt(3));
     // If cyclic condition is set to 2*R_b then max distance is sqrt(3) 2 * R_b
   }
   if (config.streamMomentumOn) {


### PR DESCRIPTION
Option to save radial energy distribution. Saved when number density is also saved.