### PR TITLE
Request RTX gpu explicitly

### DIFF
--- a/scripts/bubblesim-gpu-p4.sh
+++ b/scripts/bubblesim-gpu-p4.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH -p gpu
-#SBATCH --gpus 1
+#SBATCH --gres gpu:rtx:1
 #SBATCH --mem-per-gpu=2G
 #SBATCH -o logs/slurm-%x-%j-%N.out
 


### PR DESCRIPTION
to avoid running on new A100 accidentally without having tuned the simulation parameters beforehand for the new device.